### PR TITLE
Update bond_gran.cpp to allow fix balance command.

### DIFF
--- a/src/bond_gran.cpp
+++ b/src/bond_gran.cpp
@@ -43,6 +43,7 @@
 #include "update.h"
 #include "vector_liggghts.h"
 #include "math_const.h"
+#include "atom_vec.h" // Needed for atom->avec->grow command
 
 using namespace LAMMPS_NS;
 
@@ -93,6 +94,9 @@ BondGran::BondGran(LAMMPS *lmp) : Bond(lmp)
     if(comm->me == 0)
         error->warning(FLERR,"Bond granular: This is a beta version - be careful!");
     fix_Temp = NULL;
+    
+    // Grow arrays to include new bond history value
+    if (atom->nmax) atom->avec->grow(atom->nmax);
 }
 
 /* ---------------------------------------------------------------------- */


### PR DESCRIPTION
Added fix for bond history values to be allocated after setting bond/gran.

Tested with the chute wear example that I originally gave.
